### PR TITLE
Give a useful error when no JVMCI version info can be retrieved

### DIFF
--- a/mx.jvmci/mx_jvmci.py
+++ b/mx.jvmci/mx_jvmci.py
@@ -1470,6 +1470,8 @@ def _jvmci_versions_in_current_branch():
             m = jvmci_tag_re.match(decoration)
             if m:
                 versions.append(tuple([int(g) for g in m.groups()]))
+    if not versions:
+        mx.abort('No JVMCI versions found. If this is a shallow clone of the git repo, it may need to be unshallowed and load tags with `git fetch --unshallow --tags`')
     return versions
 
 def _get_jvmci_version():


### PR DESCRIPTION
Hi:

I just ran into an issue when trying to build this repo on MacOS (since there don't seem to be binaries at the moment).

Problem: I cloned with `git clone --depth 1`, and got a index out of bounds on the JVMCI versions.

The following patch gives a hint how to resolve it, though, it's probably not the best way.
And I don't know how mx usually communicates such errors.

Either suggestions welcome, or if you prefer, treat this simply as a "feature request".

Thanks!

/cc @dougxc 